### PR TITLE
C array

### DIFF
--- a/src/game.h
+++ b/src/game.h
@@ -700,6 +700,6 @@ Move* Chess::genMove(Move* legal_moves) const {
 template<Color color>
 inline MoveArray<color> Chess::getMoves() const {
     MoveArray<color> moves;
-    moves.last = this->genMove(moves.arr);
+    moves.last = this->genMove<color>(moves.arr);
     return moves;
 }

--- a/src/game.h
+++ b/src/game.h
@@ -39,7 +39,7 @@ class Chess {
     }
 
   public:
-  	template<Color color> std::vector<Move> getMoves() const;
+  	template<Color color> MoveArray getMoves() const;
     template<Color color> void makeMove(Move move);
     template<Color color> void unmakeMove(Move move);
 
@@ -324,9 +324,8 @@ void Chess::unmakeMove(Move move) {
 }
 
 template<Color color>
-std::vector<Move> Chess::getMoves() const {
-	std::vector<Move> legal_moves;
-	legal_moves.reserve(48);
+MoveArray Chess::getMoves() const {
+	MoveArray legal_moves;
 
 	Bitboard bb; //Temp bitboard used for whatever
 	Bitboard moves; //Temp bitboard to store moves

--- a/src/perft.cpp
+++ b/src/perft.cpp
@@ -8,7 +8,7 @@ uint64_t search(int depth, Chess *game) {
         return 1;
     }
 
-    std::vector<Move> moves = game->getMoves<color>();
+    MoveArray moves = game->getMoves<color>();
 
     uint64_t positions = 0;
 

--- a/src/piece.h
+++ b/src/piece.h
@@ -117,6 +117,33 @@ struct Move {
 
 };
 
+constexpr size_t MOVE_VECTOR_SIZE = 1000;
+
+struct MoveArray {
+  private:
+    Move arr[MOVE_VECTOR_SIZE];
+    Move *last;
+  public:
+    MoveArray() : last(arr) {}
+
+    inline Move* begin() {
+        return arr;
+    }
+
+    inline Move* end() {
+        return last;
+    }
+
+    inline size_t size() {
+        return last - arr;
+    }
+
+    inline void push_back(Move move) {
+        arr[size()] = move;
+        last++;
+    }
+};
+
 inline Bitboard sliding_moves(Bitboard occupancy, Bitboard mask, Bitboard piece_square_bitboard) {
     return (((occupancy & mask) - piece_square_bitboard) ^
         bswap_64(bswap_64(occupancy & mask) - bswap_64(piece_square_bitboard))) & mask;
@@ -160,7 +187,7 @@ inline Bitboard get_attacks<King>(int pos_idx, Bitboard occupancy) {
 }
 
 template<Flag flag = QUIET>
-inline void add_moves(uint8_t piece_pos, Bitboard move_bitboard, std::vector<Move> &moves) {
+inline void add_moves(uint8_t piece_pos, Bitboard move_bitboard, MoveArray &moves) {
     while (move_bitboard) {
         moves.push_back(Move(piece_pos, bitScanForward(move_bitboard), flag));
         move_bitboard &= move_bitboard - 1;
@@ -169,7 +196,7 @@ inline void add_moves(uint8_t piece_pos, Bitboard move_bitboard, std::vector<Mov
 
 //Used to add all capture promotions
 template<>
-inline void add_moves<PROMOTION_CAPTURE>(uint8_t piece_pos, Bitboard move_bitboard, std::vector<Move> &moves) {
+inline void add_moves<PROMOTION_CAPTURE>(uint8_t piece_pos, Bitboard move_bitboard, MoveArray &moves) {
     while (move_bitboard) {
         moves.push_back(Move(piece_pos, bitScanForward(move_bitboard), PROMOTION_CAPTURE_KNIGHT));
         moves.push_back(Move(piece_pos, bitScanForward(move_bitboard), PROMOTION_CAPTURE_BISHOP));

--- a/src/piece.h
+++ b/src/piece.h
@@ -129,11 +129,11 @@ struct MoveArray {
         return arr;
     }
 
-    inline Move* end() {
+    inline Move* end() const {
         return last;
     }
 
-    inline size_t size() {
+    inline size_t size() const {
         return last - arr;
     }
 

--- a/src/piece.h
+++ b/src/piece.h
@@ -117,16 +117,15 @@ struct Move {
 
 };
 
-constexpr size_t MOVE_VECTOR_SIZE = 1000;
+constexpr size_t MOVE_VECTOR_SIZE = 256;
 
+template<Color color>
 struct MoveArray {
   private:
     Move arr[MOVE_VECTOR_SIZE];
     Move *last;
   public:
-    MoveArray() : last(arr) {}
-
-    inline Move* begin() {
+    inline const Move* begin() const {
         return arr;
     }
 
@@ -138,10 +137,8 @@ struct MoveArray {
         return last - arr;
     }
 
-    inline void push_back(Move move) {
-        arr[size()] = move;
-        last++;
-    }
+    friend class Chess;
+
 };
 
 inline Bitboard sliding_moves(Bitboard occupancy, Bitboard mask, Bitboard piece_square_bitboard) {
@@ -187,21 +184,21 @@ inline Bitboard get_attacks<King>(int pos_idx, Bitboard occupancy) {
 }
 
 template<Flag flag = QUIET>
-inline void add_moves(uint8_t piece_pos, Bitboard move_bitboard, MoveArray &moves) {
+inline void add_moves(uint8_t piece_pos, Bitboard move_bitboard, Move* &moves) {
     while (move_bitboard) {
-        moves.push_back(Move(piece_pos, bitScanForward(move_bitboard), flag));
+        *moves++ = Move(piece_pos, bitScanForward(move_bitboard), flag);
         move_bitboard &= move_bitboard - 1;
     }
 }
 
 //Used to add all capture promotions
 template<>
-inline void add_moves<PROMOTION_CAPTURE>(uint8_t piece_pos, Bitboard move_bitboard, MoveArray &moves) {
+inline void add_moves<PROMOTION_CAPTURE>(uint8_t piece_pos, Bitboard move_bitboard, Move* &moves) {
     while (move_bitboard) {
-        moves.push_back(Move(piece_pos, bitScanForward(move_bitboard), PROMOTION_CAPTURE_KNIGHT));
-        moves.push_back(Move(piece_pos, bitScanForward(move_bitboard), PROMOTION_CAPTURE_BISHOP));
-        moves.push_back(Move(piece_pos, bitScanForward(move_bitboard), PROMOTION_CAPTURE_ROOK));
-        moves.push_back(Move(piece_pos, bitScanForward(move_bitboard), PROMOTION_CAPTURE_QUEEN));
+        *moves++ = Move(piece_pos, bitScanForward(move_bitboard), PROMOTION_CAPTURE_KNIGHT);
+        *moves++ = Move(piece_pos, bitScanForward(move_bitboard), PROMOTION_CAPTURE_BISHOP);
+        *moves++ = Move(piece_pos, bitScanForward(move_bitboard), PROMOTION_CAPTURE_ROOK);
+        *moves++ = Move(piece_pos, bitScanForward(move_bitboard), PROMOTION_CAPTURE_QUEEN);
         move_bitboard &= move_bitboard - 1;
     }
 }


### PR DESCRIPTION
std::vector<Move> is now replaced with a regular c array for a performance boost. A MoveArray struct is returned to make it easier to interact with the array. ~26,000,000 nps to ~43,000,000 nps (MacBook Air)